### PR TITLE
fix: undismissable modal still can be closed with escape key

### DIFF
--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -44,6 +44,7 @@ const ModalContent = React.forwardRef<
           'flex flex-col gap-4 sm:gap-6 p-4 sm:p-6',
           className,
         ])}
+        onEscapeKeyDown={(e) => !dismissible && e.preventDefault()}
         onPointerDownOutside={(e) => !dismissible && e.preventDefault()}
         ref={ref}
         {...props}


### PR DESCRIPTION
fix: undismissable modal still can be closed with escape key

- sandbox/modal